### PR TITLE
deprecate --model_size argument

### DIFF
--- a/scripts/merge_llama_with_chinese_lora_to_hf.py
+++ b/scripts/merge_llama_with_chinese_lora_to_hf.py
@@ -72,6 +72,8 @@ lora_model = PeftModel.from_pretrained(
 
 assert torch.allclose(first_weight_old, first_weight)
 
+print(f"Peft version: {peft.__version__}")
+print(f"Merging model")
 if peft.__version__ > '0.2.0':
     # merge weights - new merging method from peft
     lora_model = lora_model.merge_and_unload()


### PR DESCRIPTION
移除了--model_size参数；
更新了merge_llama_with_chinese_lora.py脚本中lora权重的合并方式，与merge_llama_with_chinese_lora_to_hf.py中的方式一致，以防止peft版本升级导致合并错误。