### PR TITLE
Fixed data duplication issue caused by special pattern in file names

### DIFF
--- a/scripts/training/run_clm_pt_with_peft.py
+++ b/scripts/training/run_clm_pt_with_peft.py
@@ -454,7 +454,7 @@ def main():
             files = [files[0]]
         for idx, file in enumerate(files):
             data_file = os.path.join(path, file)
-            filename = file.split(".")[0]
+            filename = ''.join(file.split(".")[:-1])
             cache_path = os.path.join(data_args.data_cache_dir, filename)
             os.makedirs(cache_path, exist_ok=True)
             try:


### PR DESCRIPTION
Update run_clm_pt_with_peft.py:
when pretrain file names are: x.y1.txt and x.y2.txt, cache_dir is both `x`, this will cause unexpected data duplication.