### PR TITLE
Fix smart_tokenizer_and_embedding_resize in SFT script

### DIFF
--- a/scripts/training/run_clm_sft_with_peft.py
+++ b/scripts/training/run_clm_sft_with_peft.py
@@ -449,7 +449,6 @@ def main():
 def smart_tokenizer_and_embedding_resize(
     special_tokens_dict: Dict,
     tokenizer: transformers.PreTrainedTokenizer,
-    model: transformers.PreTrainedModel,
 ):
     """Resize tokenizer and embedding.
     Note: This is the unoptimized version that may make your embedding size not be divisible by 64.


### PR DESCRIPTION
### Description

Fix the bug in function `smart_tokenizer_and_embedding_resize` due to redundant argument `model`

### Related Issue
https://github.com/ymcui/Chinese-LLaMA-Alpaca/issues/616