### PR TITLE
fix system message attribute error

### DIFF
--- a/scripts/openai_server_demo/openai_api_server.py
+++ b/scripts/openai_server_demo/openai_api_server.py
@@ -93,7 +93,7 @@ def generate_chat_prompt(messages: list):
     system_msg = '''Below is an instruction that describes a task. Write a response that appropriately completes the request.'''
     for msg in messages:
         if msg.role == 'system':
-            system_msg = msg.message
+            system_msg = msg.content
     prompt = f"{system_msg}\n\n"
     for msg in messages:
         if msg.role == 'system':


### PR DESCRIPTION
When you make a request to the /v1/chat/completions, the message field will be changed to content. So, when you use it later, make sure to refer to the content field instead.