### PR TITLE
Fix a typo in the function name

### DIFF
--- a/scripts/training/build_dataset.py
+++ b/scripts/training/build_dataset.py
@@ -18,7 +18,7 @@ PROMPT_TEMPLATE = (
         "### Instruction:\n{instruction}\n\n### Response: "
     )
 
-def buid_instruction_dataset(data_path: Union[List[str],str],
+def build_instruction_dataset(data_path: Union[List[str],str],
                 tokenizer: transformers.PreTrainedTokenizer,
                 max_seq_length: int, data_cache_dir = None,
                 preprocessing_num_workers = None,

--- a/scripts/training/run_clm_sft_with_peft.py
+++ b/scripts/training/run_clm_sft_with_peft.py
@@ -30,7 +30,7 @@ from typing import Optional
 from pathlib import Path
 import datasets
 import torch
-from build_dataset import buid_instruction_dataset, DataCollatorForSupervisedDataset
+from build_dataset import build_instruction_dataset, DataCollatorForSupervisedDataset
 import transformers
 from transformers import (
     CONFIG_MAPPING,
@@ -312,7 +312,7 @@ def main():
             path = Path(data_args.dataset_dir)
             files = [os.path.join(path,file.name) for file in path.glob("*.json")]
             logger.info(f"training files: {' '.join(files)}")
-            train_dataset = buid_instruction_dataset(
+            train_dataset = build_instruction_dataset(
                 data_path=files,
                 tokenizer=tokenizer,
                 max_seq_length=data_args.max_seq_length,
@@ -325,7 +325,7 @@ def main():
         with training_args.main_process_first(desc="loading and tokenization"):
             files = [data_args.validation_file]
             logger.info(f"training files: {' '.join(files)}")
-            eval_dataset = buid_instruction_dataset(
+            eval_dataset = build_instruction_dataset(
                 data_path=files,
                 tokenizer=tokenizer,
                 max_seq_length=data_args.max_seq_length,

--- a/scripts/training/run_clm_sft_with_peft.py
+++ b/scripts/training/run_clm_sft_with_peft.py
@@ -324,7 +324,7 @@ def main():
     if training_args.do_eval:
         with training_args.main_process_first(desc="loading and tokenization"):
             files = [data_args.validation_file]
-            logger.info(f"training files: {' '.join(files)}")
+            logger.info(f"Training files: {' '.join(files)}")
             eval_dataset = build_instruction_dataset(
                 data_path=files,
                 tokenizer=tokenizer,


### PR DESCRIPTION
### Description

Change the name of the function `buid_instruction_dataset` to `build_instruction_dataset` in `build_dataset.py` and `run_clm_sft_with_peft.py`.

### Related Issue

None