### PR TITLE
fix vocab_size after low-mem-merge

### DIFF
--- a/scripts/merge_llama_with_chinese_lora_low_mem.py
+++ b/scripts/merge_llama_with_chinese_lora_low_mem.py
@@ -336,6 +336,8 @@ if __name__=='__main__':
                 print(f"Saving {config}")
                 with open(os.path.join(base_model_path, config),'r') as f:
                     obj = json.load(f)
+                if config=='config.json':
+                    obj['vocab_size'] = len(tokenizers_and_loras[-1]['tokenizer'])
                 if config=='pytorch_model.bin.index.json':
                     obj['metadata']['total_size'] = total_size
                 with open(os.path.join(output_dir, config), 'w') as f:


### PR DESCRIPTION
### Description

In the original low-mem-merge script, `vocab_size` of the merged model is not updated and remains 32000.
In this PR, I fix the bug and update `vocal_size` to the length of the tokenizer (with is 49953 for LLaMA and 49954 for Alpaca)

### Related Issue

https://github.com/ymcui/Chinese-LLaMA-Alpaca/issues/681#issuecomment-1616701097
