### PR TITLE
Update inference_hf.py for repetition_penalty

### DIFF
--- a/scripts/inference/inference_hf.py
+++ b/scripts/inference/inference_hf.py
@@ -31,7 +31,7 @@ generation_config = dict(
     top_p=0.9,
     do_sample=True,
     num_beams=1,
-    repetition_penalty=1.3,
+    repetition_penalty=1.1,
     max_new_tokens=400
     )
 


### PR DESCRIPTION
### Description
Fix default `repetition_penalty` param from `1.3` to `1.1` in `inference_hf.py`.

### Related Issue
None.

### Explanation of Changes
copilot:walkthrough
